### PR TITLE
Un-reverting "Added value builder data source to select component"

### DIFF
--- a/components/select.js
+++ b/components/select.js
@@ -33,27 +33,35 @@ app.config([
         $scope.selectItems = [];
         var valueProp = $scope.component.valueProperty;
         $scope.getSelectItem = function(item) {
+          if(settings.dataSrc === 'values') {
+            return 'value';
+          }
           return valueProp ? item[valueProp] : item;
         };
 
-        if (settings.dataSrc.substr(0, 1) === '/') {
-          settings.dataSrc = Formio.baseUrl + settings.dataSrc;
-        }
-
-        // If this is a url, then load the file.
-        if (settings.dataSrc.substr(0, 4) === 'http') {
-          $http.get(settings.dataSrc)
-            .success(function(data) {
-              $scope.selectItems = data;
-            });
-        }
-        else if (settings.dataSrc) {
-          try {
-            $scope.selectItems = angular.fromJson(settings.dataSrc);
-          }
-          catch (error) {
+        switch(settings.dataSrc) {
+          case 'values':
+            $scope.selectItems = settings.data.values;
+            break;
+          case 'json':
+            try {
+              $scope.selectItems = angular.fromJson(settings.data.json);
+            }
+            catch (error) {
+              $scope.selectItems = [];
+            }
+            break;
+          case 'url':
+            if(settings.data.url.substr(0, 1) === '/') {
+              settings.data.url = Formio.baseUrl + settings.data.url;
+            }
+            $http.get(settings.data.url)
+              .success(function(data) {
+                $scope.selectItems = data;
+              });
+            break;
+          default:
             $scope.selectItems = [];
-          }
         }
       },
       settings: {
@@ -62,7 +70,19 @@ app.config([
         label: '',
         key: '',
         placeholder: '',
-        dataSrc: '',
+        data: {
+          values: [{
+            value: 'value1',
+            label: 'Value 1'
+          },
+          {
+            value: 'value2',
+            label: 'Value 2'
+          }],
+          json: '',
+          url: ''
+        },
+        dataSrc: 'values',
         valueProperty: '',
         template: '<span>{{ item }}</span>',
         multiple: false,


### PR DESCRIPTION
Here is the update query:
```javascript
db.forms.find({components: {$elemMatch: {type: "select", data: {$exists: false}}}}).forEach(function(doc){
    var urlRegex = new RegExp('^http|^\/', 'i');
    var newComponents = doc.components.map(function(c){
        if(c.type != "select" || c.data)
            return c;
        // url datasrc
        c.data = {
            values: [{
                value: 'value1',
                label: 'Value 1'
            },
            {
                value: 'value2',
                label: 'Value 2'
            }],
            json: '',
            url: ''
        };
        if(urlRegex.test(c.dataSrc)) {
            c.data.url = c.dataSrc;
            c.dataSrc = 'url';
        }
        else {
            c.data.json = c.dataSrc;
            c.dataSrc = 'json';
        }
        return c;
    });
    print(db.forms.update({_id: doc._id}, {$set: {components: newComponents}}));
}, {multi: true});
```