### PR TITLE
Move container out of layout components.

### DIFF
--- a/src/components/container.js
+++ b/src/components/container.js
@@ -7,7 +7,7 @@ module.exports = function(app) {
         title: 'Container',
         template: 'formio/components/container.html',
         viewTemplate: 'formio/componentsView/container.html',
-        group: 'layout',
+        group: 'advanced',
         icon: 'fa fa-folder-open',
         settings: {
           input: true,

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -25,13 +25,13 @@ require('./resource')(app);
 require('./file')(app);
 require('./signature')(app);
 require('./custom')(app);
+require('./container')(app);
 require('./datagrid')(app);
 require('./survey')(app);
 
 // Layout
 require('./columns')(app);
 require('./fieldset')(app);
-require('./container')(app);
 require('./page')(app);
 require('./panel')(app);
 require('./table')(app);


### PR DESCRIPTION
Lots of people keep getting confused by the container component. It is not actually a layout component but people keep using it as such. It is actually supposed to put all fields within it inside an object with a key. Thus it is for mutating data, not layout purposes. I've moved it near the datagrid which does a similar purpose.