### PR TITLE
added check newValue!=oldValue in refreshOn watch

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -179,8 +179,8 @@ module.exports = function(app) {
             else {
               $scope.$watch('data.' + settings.refreshOn, function(newValue, oldValue) {
                 $scope.refreshItems();
-				if (settings.clearOnRefresh && newValue!=oldValue) { 
-                  $scope.data[settings.key] = settings.multiple ? [] : '';
+				if (settings.clearOnRefresh && newValue !== oldValue) {
+					$scope.data[settings.key] = settings.multiple ? [] : '';
                 }
               });
             }

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -177,9 +177,9 @@ module.exports = function(app) {
               }, true);
             }
             else {
-              $scope.$watch('data.' + settings.refreshOn, function() {
+              $scope.$watch('data.' + settings.refreshOn, function(newValue, oldValue) {
                 $scope.refreshItems();
-                if (settings.clearOnRefresh) {
+				if (settings.clearOnRefresh && newValue!=oldValue) { 
                   $scope.data[settings.key] = settings.multiple ? [] : '';
                 }
               });


### PR DESCRIPTION
to avoid clearing of value when form pre populated during edit mode
and object reassigned by underlying API request.

eg. Country dropdown populating State values for State dropdown and refreshOn option is used.
When binding form in edit mode, default value is cleared due to the watch executed during form init loading State values