### PR TITLE
Fix various issues with the file upload component

### DIFF
--- a/src/components/file.js
+++ b/src/components/file.js
@@ -41,6 +41,9 @@ module.exports = function(app) {
         function($scope) {
           if ($scope.builder) return;
           $scope.removeFile = function(event, index) {
+            var component = $scope.$parent.component;
+            if (component.storage == 'url')
+              $scope.$parent.formio.makeRequest('', component.url + '/' + $scope.files[index].name, 'delete');
             event.preventDefault();
             $scope.files.splice(index, 1);
           };
@@ -69,6 +72,9 @@ module.exports = function(app) {
         function($scope) {
           if ($scope.builder) return;
           $scope.removeFile = function(event, index) {
+            var component = $scope.$parent.component;
+            if (component.storage == 'url')
+              $scope.$parent.formio.makeRequest('', component.url + '/' + $scope.files[index].name, 'delete');
             event.preventDefault();
             $scope.files.splice(index, 1);
           };
@@ -128,7 +134,7 @@ module.exports = function(app) {
         form: '=',
         width: '='
       },
-      template: '<img ng-src="{{ imageSrc }}" alt="{{ file.name }}" ng-style="{width: width}" />',
+      template: '<img ng-src="{{ file.imageSrc }}" alt="{{ file.name }}" ng-style="{width: width}" />',
       controller: [
         '$rootScope',
         '$scope',
@@ -143,7 +149,7 @@ module.exports = function(app) {
           var formio = new Formio($scope.form);
           formio.downloadFile($scope.file)
             .then(function(result) {
-              $scope.imageSrc = result.url;
+              $scope.file.imageSrc = result.url;
               $scope.$apply();
             });
         }
@@ -166,6 +172,9 @@ module.exports = function(app) {
 
       // This fixes new fields having an empty space in the array.
       if ($scope.data && $scope.data[$scope.component.key] === '') {
+        $scope.data[$scope.component.key] = [];
+      }
+      if ($scope.data && $scope.data[$scope.component.key] === undefined) {
         $scope.data[$scope.component.key] = [];
       }
       if ($scope.data && $scope.data[$scope.component.key] && $scope.data[$scope.component.key][0] === '') {

--- a/src/components/file.js
+++ b/src/components/file.js
@@ -42,8 +42,9 @@ module.exports = function(app) {
           if ($scope.builder) return;
           $scope.removeFile = function(event, index) {
             var component = $scope.$parent.component;
-            if (component.storage == 'url')
+            if (component.storage === 'url') {
               $scope.$parent.formio.makeRequest('', component.url + '/' + $scope.files[index].name, 'delete');
+            }
             event.preventDefault();
             $scope.files.splice(index, 1);
           };
@@ -73,8 +74,9 @@ module.exports = function(app) {
           if ($scope.builder) return;
           $scope.removeFile = function(event, index) {
             var component = $scope.$parent.component;
-            if (component.storage == 'url')
+            if (component.storage === 'url') {
               $scope.$parent.formio.makeRequest('', component.url + '/' + $scope.files[index].name, 'delete');
+            }
             event.preventDefault();
             $scope.files.splice(index, 1);
           };


### PR DESCRIPTION
With display file as image option set upload 3 files.  Delete the second.  Correct file will be deleted from array but images will appear as if the last one had been deleted.

Also send delete requests to server for URL storage when deleting.  This should probably be done for Dropbox and S3 too but I'm not in a position code or test that now.