### PR TITLE
Only include has-feedback style when necessary

### DIFF
--- a/src/templates/component.html
+++ b/src/templates/component.html
@@ -1,3 +1,8 @@
-<div class="form-group has-feedback form-field-type-{{ component.type }} formio-component-{{ component.key }} {{component.customClass}}" id="form-group-{{ componentId }}" ng-class="{'has-error': formioForm[componentId].$invalid && !formioForm[componentId].$pristine }" ng-style="component.style" ng-hide="component.hidden">
+<div class="form-group form-field-type-{{ component.type }} formio-component-{{ component.key }} {{component.customClass}}" id="form-group-{{ componentId }}"
+     ng-class="{'has-feedback ': (component.hideLabel === true || component.label === '' || !component.label) && component.validate.required,
+             'has-error': formioForm[componentId].$invalid && !formioForm[componentId].$pristine }"
+     ng-style="component.style"
+     ng-hide="component.hidden">
   <formio-element></formio-element>
 </div>
+


### PR DESCRIPTION
Make has-feedback style conditional so it's only applied when needed.  This will save browser space which becomes precious when components are in a datagrid.