### PR TITLE
Restore hyphen between between "col-sm-offset" and number

### DIFF
--- a/src/templates/components/columns.html
+++ b/src/templates/components/columns.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div ng-show="column.width" class="col-sm-{{column.width}} col-sm-offset{{column.offset}} col-sm-push-{{column.push}} col-sm-pull-{{column.pull}}" ng-repeat="column in component.columns track by $index">
+  <div ng-show="column.width" class="col-sm-{{column.width}} col-sm-offset-{{column.offset}} col-sm-push-{{column.push}} col-sm-pull-{{column.pull}}" ng-repeat="column in component.columns track by $index">
     <formio-component
       ng-repeat="_component in column.components track by $index"
       component="_component"


### PR DESCRIPTION
In change from "ng-class" to "class" for columns component hyphen for offset got lost