### PR TITLE
Provide submission data to Advanced Next Page code evaluation

### DIFF
--- a/src/directives/formioWizard.js
+++ b/src/directives/formioWizard.js
@@ -368,7 +368,9 @@ module.exports = function() {
             // Allow for script execution.
             if (typeof currentPage.nextPage === 'string') {
               try {
-                eval(currentPage.nextPage.toString());
+                var next = nextPage;
+                eval('(function(data) {' + currentPage.nextPage.toString() + '})($scope.submission.data)');
+                page = next;
                 if (!isNaN(parseInt(page, 10)) && isFinite(page)) {
                   return page;
                 }


### PR DESCRIPTION
Builder says that **data** will be provided to Advanced Next Page code.
Fix passes it from $scope.submission.data.
Builder also says to assign **next** variable.
Fix also provides that and assigns it to page variable.