### PR TITLE
Default clearOnHide setting to false for container components

### DIFF
--- a/src/components/columns.js
+++ b/src/components/columns.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
         template: 'formio/components/columns.html',
         group: 'layout',
         settings: {
+          clearOnHide: false,
           input: false,
           tableView: false,
           key: 'columns',

--- a/src/components/fieldset.js
+++ b/src/components/fieldset.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
         template: 'formio/components/fieldset.html',
         group: 'layout',
         settings: {
+          clearOnHide: false,
           key: 'fieldset',
           input: false,
           tableView: false,

--- a/src/components/form.js
+++ b/src/components/form.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
         template: 'formio/components/form.html',
         group: 'advanced',
         settings: {
+          clearOnHide: false,
           input: true,
           tableView: true,
           key: 'formField',

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
         template: 'formio/components/panel.html',
         group: 'layout',
         settings: {
+          clearOnHide: false,
           key: 'panel',
           input: false,
           title: '',

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
         template: 'formio/components/table.html',
         group: 'layout',
         settings: {
+          clearOnHide: false,
           input: false,
           key: 'table',
           numRows: 3,

--- a/src/components/well.js
+++ b/src/components/well.js
@@ -10,6 +10,7 @@ module.exports = function(app) {
         template: 'formio/components/well.html',
         group: 'layout',
         settings: {
+          clearOnHide: false,
           key: 'well',
           input: false,
           components: [],


### PR DESCRIPTION
Unchecking _Clear Value When Hidden_ for contained components doesn't help when container setting defaults to true and can't be changed.