### PR TITLE
Submit subforms on the page when wizard's Previous button is clicked

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -69,6 +69,11 @@ module.exports = function(app) {
             submitForm(scope, cb);
           });
 
+          // Hook into the prevpage method.
+          FormioUtils.hook($scope.component.key + ':prevPage', function(scope, cb) {
+            submitForm(scope, cb);
+          });
+
           // See if we need to load the submission into scope.
           if (
             $scope.data[$scope.component.key] &&

--- a/src/directives/formioWizard.js
+++ b/src/directives/formioWizard.js
@@ -445,6 +445,17 @@ module.exports = function() {
 
         // Move onto the previous page.
         $scope.prev = function() {
+          var errors = $scope.checkErrors();
+          if (errors) {
+            $scope.pageHasErrors[$scope.currentPage] = true;
+            if (!$scope.formioOptions.wizardFreeNavigation) {
+              return;
+            }
+          }
+          else {
+            $scope.pageHasErrors[$scope.currentPage] = false;
+          }
+
           var prev = $scope.history.pop();
           $scope.currentPage = prev;
           FormioUtils.alter('prevPage', $scope, function(err) {


### PR DESCRIPTION
Using wizard with conditional panels it's possible to fill out page X, click Previous button and page X may become hidden.  (Do Not Try This At Home!)
As a result page X may not be checked for errors and subforms within it may not be submitted.
This becomes more important when combined with pull request #435.
Added error checking on Previous button click and hooked prevPage so subforms get submitted.