### PR TITLE
Support submission of form components which are not in wizard panels

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -49,7 +49,14 @@ module.exports = function(app) {
           });
 
           var submitForm = function(scope, cb) {
-            if (FormioUtils.getComponent(scope.activePage.components, $scope.component.key)) {
+            var components = [];
+            if (scope.activePage) {
+              components = scope.activePage.components;
+            }
+            else if (scope.form) {
+              components = scope.form.components;
+            }
+            if (FormioUtils.getComponent(components, $scope.component.key)) {
               $scope.formFormio.saveSubmission(angular.copy($scope.data[$scope.component.key])).then(function(sub) {
                 angular.merge($scope.data[$scope.component.key], sub);
                 cb();


### PR DESCRIPTION
Currently form components outside of wizard panels won't submit because there is no active page.
Adjust component key lookup to search form components if there is no active page.
Tested and it's working for me.
Could be useful for multi-form workflows that don't require full blown wizard.