### PR TITLE
Fixed crash in FormioUtils each error handling assigning property to a string

### DIFF
--- a/src/directives/formio.js
+++ b/src/directives/formio.js
@@ -301,6 +301,7 @@ module.exports = function() {
           form.submitting = true;
           FormioUtils.alter('submit', $scope, $scope.submission, function(err) {
             if (err) {
+              form.submitting = false;
               return this.showAlerts(err.alerts);
             }
 

--- a/src/factories/FormioUtils.js
+++ b/src/factories/FormioUtils.js
@@ -15,6 +15,9 @@ module.exports = function() {
 
       (function next(err, previous) {
         if (err) {
+          if (typeof err === 'string') {
+            err = {alerts: {type: 'danger', message: '{"data": "' + err + '"}'}};
+          }
           err.item = previous;
           return done ? done(err) : null;
         }


### PR DESCRIPTION
In FormioUtils _each_ the function _next_ may be called with _err_ set to a string.
For example 'Name must be unique.'
Attempt to set err.item = previous will cause exception "Cannot create property 'item' on string 'Name must be unique.'"
If err is a string convert it into an alert object.

To reproduce create form A with Name component where Unique is checked.
Create form B which contains subform component which refers to form A.
Submit B with same Name twice.

Submission of subform may have multiple errors but only the first one appears in _err_ so feedback to user is correct if incomplete.

Also stop Submit button spinner when submission fails as described above.
