### PR TITLE
Fix message that submission was created when it was really updated

### DIFF
--- a/src/directives/formio.js
+++ b/src/directives/formio.js
@@ -236,7 +236,8 @@ module.exports = function() {
             // copy to remove angular $$hashKey
             var submissionMethod = submissionData._id ? 'put' : 'post';
             $scope.formio.saveSubmission(submissionData, $scope.formioOptions).then(function(submission) {
-              onSubmitDone(submissionMethod, submission, form);
+              submission.method = submissionMethod;
+              onSubmitDone(submission.method, submission, form);
             }, FormioScope.onError($scope, $element)).finally(function() {
               if (form) {
                 form.submitting = false;

--- a/src/directives/formio.js
+++ b/src/directives/formio.js
@@ -234,9 +234,9 @@ module.exports = function() {
           // If they wish to submit to the default location.
           else if ($scope.formio && !$scope.formio.noSubmit) {
             // copy to remove angular $$hashKey
-            var method = submissionData._id ? 'put' : 'post';
+            var submissionMethod = submissionData._id ? 'put' : 'post';
             $scope.formio.saveSubmission(submissionData, $scope.formioOptions).then(function(submission) {
-              onSubmitDone(method, submission, form);
+              onSubmitDone(submissionMethod, submission, form);
             }, FormioScope.onError($scope, $element)).finally(function() {
               if (form) {
                 form.submitting = false;

--- a/src/directives/formio.js
+++ b/src/directives/formio.js
@@ -234,8 +234,9 @@ module.exports = function() {
           // If they wish to submit to the default location.
           else if ($scope.formio && !$scope.formio.noSubmit) {
             // copy to remove angular $$hashKey
+            var method = submissionData._id ? 'put' : 'post';
             $scope.formio.saveSubmission(submissionData, $scope.formioOptions).then(function(submission) {
-              onSubmitDone(submission.method, submission, form);
+              onSubmitDone(method, submission, form);
             }, FormioScope.onError($scope, $element)).finally(function() {
               if (form) {
                 form.submitting = false;


### PR DESCRIPTION
Expectation is that _submission.method_ will contain 'post' or 'put' but in fact it is always undefined.
Set it according to submission previously having had an _id.