### PR TITLE
If submission saved propagate method to ngFormioHelper for correct message

### DIFF
--- a/src/directives/formio.js
+++ b/src/directives/formio.js
@@ -236,6 +236,10 @@ module.exports = function() {
             // copy to remove angular $$hashKey
             var submissionMethod = submissionData._id ? 'put' : 'post';
             $scope.formio.saveSubmission(submissionData, $scope.formioOptions).then(function(submission) {
+              // If submission saved propagate method to ngFormioHelper for correct message
+              if (typeof submission === 'object') {
+                submission.method = submissionMethod;
+              }
               onSubmitDone(submissionMethod, submission, form);
             }, FormioScope.onError($scope, $element)).finally(function() {
               if (form) {


### PR DESCRIPTION
Sorry pull request #449 caused crash.
Forgot to test case of form with no save action.
Nevertheless ngFormioHelper is still looking at _submission.method_ and will always report submission was created when it was really updated if it's left undefined.
Change will set _submission.method_ only if _submission_ is already an object.

