### PR TITLE
Remove premature call to ensureValue which causes missing selection

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -563,7 +563,6 @@ module.exports = function(app) {
                   };
                   $scope.refreshItems(true);
                 }
-                ensureValue();
                 break;
               default:
                 $scope.selectItems = [];


### PR DESCRIPTION
Running Chrome on Windows 10.

Created a form which contains a Select from URL component and a Select from Resource component.
Select from URL has Data Source URL of _http://localhost:3001/form?type=resource_ and Value Property of __id_.
Select from Resource has Value set to _Submission Id_.
Made selections for both components and submitted.
Edited the submission and refreshed repeatedly.
Randomly and about half the time the components do not display the previous selections (which are in the database).

Problem occurs when call to ensureValue is made before the select items have had a chance to load.
When called too early ensureValue pushes a half baked object into $scope.selectItems.
Call is unnecessary anyway since ensureValue will be called again by setResult when the select items have loaded.

Problem also affected editing of Save Submission action which saves submission to another resource.