### PR TITLE
Make formioTranslate filter stateful

### DIFF
--- a/src/filters/translate.js
+++ b/src/filters/translate.js
@@ -5,7 +5,7 @@ module.exports = [
     $filter,
     $injector
   ) {
-    return function(text, key, builder) {
+    var formioTranslate = function(text, key, builder) {
       /**
        * Lookup the available translate libraries, currently supports:
        * angular-translate: @see https://github.com/angular-translate/angular-translate
@@ -42,5 +42,13 @@ module.exports = [
         return text;
       }
     };
+    formioTranslate.$stateful = true;
+    formioTranslate.use = function(language) {
+      if ($injector.has('$translate')) {
+        var $translate = $injector.get('$translate');
+        $translate.use(language);
+      }
+    };
+    return formioTranslate;
   }
 ];


### PR DESCRIPTION
Using formioTranslate within ng-formio-helper.
angular-translate is the underlying translater.
After refreshing Chrome on Windows 10 the string is not translated because the language file is still being loaded.
Made formioTranslate filter stateful to overcome this.
Also fixes problem of strings not updating when switching languages on the fly.

Also added helper function so people using angular-translate can easily switch languages with code like:
_var f = $filter('formioTranslate');
f.use('FRENCH');_