### PR TITLE
Translate component's descriptions

### DIFF
--- a/src/factories/FormioUtils.js
+++ b/src/factories/FormioUtils.js
@@ -347,7 +347,7 @@ module.exports = function() {
           '</div>' +
         '</div>' +
         '<div ng-if="!!component.description" class="help-block">' +
-          '<span>{{ component.description }}</span>' +
+          '<span>{{ component.description | formioTranslate:null:options.building }}</span>' +
         '</div>' +
         '<div ng-if="component.multiple"><table class="table table-bordered">' +
           inputLabel +


### PR DESCRIPTION
Some of Login action's components have descriptions.

Also noticed that if Multiple Values is checked then description renders above label and not below input.
May not be as intended.
Will fix when time allows unless someone beats me to it.