### PR TITLE
Fix babel preset dependency for latest formio.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-preset-es2015": "^6.24.0",
+    "babel-preset-env": "^1.6.1",
     "babelify": "^7.3.0",
     "brfs": "^1.4.3",
     "browserify": "^13.0.1",


### PR DESCRIPTION
Was getting...
Error: Couldn't find preset "env" relative to directory...
building with latest formio.js.
Same change had already been added to builder.