### PR TITLE
Removed Wizard's Previous Button Validation Check

### DIFF
--- a/src/directives/formioWizard.js
+++ b/src/directives/formioWizard.js
@@ -465,17 +465,8 @@ module.exports = function() {
 
         // Move onto the previous page.
         $scope.prev = function() {
-          var errors = $scope.checkErrors();
-          if (errors) {
-            $scope.pageHasErrors[$scope.currentPage] = true;
-            if (!$scope.formioOptions.wizardFreeNavigation) {
-              return;
-            }
-          }
-          else {
-            $scope.pageHasErrors[$scope.currentPage] = false;
-          }
-
+          // var errors = $scope.checkErrors();
+          $scope.pageHasErrors[$scope.currentPage] = false;
           var prev = $scope.history.pop();
           $scope.currentPage = prev;
           FormioUtils.alter('prevPage', $scope, function(err) {


### PR DESCRIPTION
Field validation is no longer checked when interacting with the "previous" button on form wizards. 