### PR TITLE
Resolved ng-disabled dynamic update issue

### DIFF
--- a/css/formio.css
+++ b/css/formio.css
@@ -71,6 +71,37 @@
   min-width: 200px;
 }
 
+/* FOR-873 */
+.bttn-disable{
+  outline: none !important;
+  cursor: not-allowed !important;
+  background-color: #7DC4EE !important;
+  border: #7DC4EE !important;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* No */
+}
+
+.bttn-disable:hover{
+  outline: none !important;
+  background-color: #7DC4EE !important;
+  border: #7DC4EE !important;
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* No */
+}
+
+.bttn-disable:active{
+  -webkit-box-shadow: none !important;
+  box-shadow: none !important;
+}
+
 /* FOR-109 */
 .input-group .form-control {
   z-index: inherit;

--- a/css/formio.css
+++ b/css/formio.css
@@ -72,7 +72,7 @@
 }
 
 /* FOR-873 */
-.bttn-disable{
+.btn-disable{
   outline: none !important;
   cursor: not-allowed !important;
   background-color: #7DC4EE !important;
@@ -85,7 +85,7 @@
   user-select: none; /* No */
 }
 
-.bttn-disable:hover{
+.btn-disable:hover{
   outline: none !important;
   background-color: #7DC4EE !important;
   border: #7DC4EE !important;
@@ -97,7 +97,7 @@
   user-select: none; /* No */
 }
 
-.bttn-disable:active{
+.btn-disable:active{
   -webkit-box-shadow: none !important;
   box-shadow: none !important;
 }

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -37,8 +37,18 @@ module.exports = function(app) {
             }
           };
 
+
+         var allowSubmission = true;
           $scope.hasError = function() {
-            return clicked && (settings.action === 'submit') && $scope.formioForm.$invalid && !$scope.formioForm.$pristine;
+            var errValue = clicked && (settings.action === 'submit') && $scope.formioForm.$invalid && !$scope.formioForm.$pristine;
+            if(errValue && settings.disableOnInvalid && $scope.formioForm.$invalid && !$scope.formioForm.$pristine){
+              allowSubmission = false;
+              $('#' +settings.key).addClass("bttn-disable");
+            }else{
+              allowSubmission = true;
+              $('#'+settings.key).removeClass("bttn-disable");
+            }
+            return errValue
           };
 
           var onCustom = function() {
@@ -59,7 +69,7 @@ module.exports = function(app) {
             }
           };
 
-          var onClick = function() {
+          var onClick = function () {
             clicked = true;
             switch (settings.action) {
               case 'submit':
@@ -98,7 +108,11 @@ module.exports = function(app) {
             if (componentId !== $scope.componentId) {
               return;
             }
-            onClick();
+            if(allowSubmission === true) {
+              onClick();
+            }else{
+              $scope.hasError();
+            }
           });
 
           $scope.openOAuth = function(settings) {

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -41,12 +41,12 @@ module.exports = function(app) {
          var allowSubmission = true;
           $scope.hasError = function() {
             var errValue = clicked && (settings.action === 'submit') && $scope.formioForm.$invalid && !$scope.formioForm.$pristine;
-            if(errValue && settings.disableOnInvalid && $scope.formioForm.$invalid && !$scope.formioForm.$pristine){
+            if (errValue && settings.disableOnInvalid && $scope.formioForm.$invalid && !$scope.formioForm.$pristine) {
               allowSubmission = false;
-              $('#' +settings.key).addClass("bttn-disable");
-            }else{
+              $scope.disableBtn = true;
+            } else {
               allowSubmission = true;
-              $('#'+settings.key).removeClass("bttn-disable");
+              $scope.disableBtn = false
             }
             return errValue
           };
@@ -108,9 +108,9 @@ module.exports = function(app) {
             if (componentId !== $scope.componentId) {
               return;
             }
-            if(allowSubmission === true) {
+            if (allowSubmission === true) {
               onClick();
-            }else{
+            } else {
               $scope.hasError();
             }
           });

--- a/src/templates/components/button.html
+++ b/src/templates/components/button.html
@@ -3,7 +3,7 @@
     name="{{ componentId }}"
     ng-class="{'btn-block': component.block}"
     class="btn btn-{{ component.theme }} btn-{{ component.size }}"
-    ng-disabled="readOnly || formioForm.submitting || (component.disableOnInvalid && formioForm.$invalid) || hasError()"
+    ng-disabled="readOnly || formioForm.submitting"
     tabindex="{{ component.tabindex || 0 }}"
     ng-click="$emit('buttonClick', component, componentId)">
   <span ng-if="component.leftIcon" class="{{ component.leftIcon }}" aria-hidden="true"></span>

--- a/src/templates/components/button.html
+++ b/src/templates/components/button.html
@@ -1,7 +1,7 @@
 <button ng-attr-type="{{ getButtonType() }}"
     id="{{ componentId }}"
     name="{{ componentId }}"
-    ng-class="{'btn-block': component.block}"
+    ng-class="{'btn-block': component.block, 'btn-disable': disableBtn}"
     class="btn btn-{{ component.theme }} btn-{{ component.size }}"
     ng-disabled="readOnly || formioForm.submitting"
     tabindex="{{ component.tabindex || 0 }}"


### PR DESCRIPTION
Previous iteration dynamically applied ng-disabled to form components causing the submissions cycle to terminate prematurely. Per the Angular.js docs ng-disabled is intended to terminate the submission cycle, the Form.io render procedure needed a way to superceed this function. A jQuery solution has been applied. 

The Following update resolved the following Validation Jira Issues

FOR-888 - WYSIWYG fails at validation
FOR-873 - Password validation persists after submission
FOR-877 – Validation on one field prevents validation on another
Unknown ticket - Submit button’s “Disable on Form Invalid” fixed