### PR TITLE
Fix issue where when files are removed, required validation no longer…

### DIFF
--- a/src/components/file.js
+++ b/src/components/file.js
@@ -169,12 +169,10 @@ module.exports = function(app) {
 
   app.controller('formioFileUpload', [
     '$scope',
-    '$element',
     '$interpolate',
     'FormioUtils',
     function(
       $scope,
-      $element,
       $interpolate,
       FormioUtils
     ) {
@@ -195,7 +193,6 @@ module.exports = function(app) {
         $scope.component.fileMaxSize = '1GB';
       }
 
-      var ngModel = $element.controller('ngModel');
       $scope.$watch('data.' + $scope.component.key, function(value) {
         // For some reason required validation doesn't fire properly after removing an item from an array which results
         // in an empty array that is marked as valid. Fix by removing the empty array.

--- a/src/components/file.js
+++ b/src/components/file.js
@@ -169,10 +169,12 @@ module.exports = function(app) {
 
   app.controller('formioFileUpload', [
     '$scope',
+    '$element',
     '$interpolate',
     'FormioUtils',
     function(
       $scope,
+      $element,
       $interpolate,
       FormioUtils
     ) {
@@ -192,6 +194,15 @@ module.exports = function(app) {
       if (!$scope.component.fileMaxSize) {
         $scope.component.fileMaxSize = '1GB';
       }
+
+      var ngModel = $element.controller('ngModel');
+      $scope.$watch('data.' + $scope.component.key, function(value) {
+        // For some reason required validation doesn't fire properly after removing an item from an array which results
+        // in an empty array that is marked as valid. Fix by removing the empty array.
+        if (Array.isArray(value) && value.length === 0) {
+          delete $scope.data[$scope.component.key];
+        }
+      }, true)
 
       $scope.upload = function(files) {
         if ($scope.component.storage && files && files.length) {


### PR DESCRIPTION
… works correctly.

This is a weird one where previously when you delete a file on a required file field the required validation does not re-fire. I think it has something to do with the built in validation not properly watching the array or something. To fix this I just made it so that if all files are deleted the empty array is removed. This triggers the validation correctly again.