### PR TITLE
 Add "component" to scope for validation scripts

### DIFF
--- a/src/components/editgrid.js
+++ b/src/components/editgrid.js
@@ -163,6 +163,7 @@ module.exports = function(app) {
             var row = scope.row;
             /*eslint-enable no-unused-vars */
 
+            var component = scope.component;
             var custom = scope.component.validate.row;
             custom = custom.replace(/({{\s{0,}(.*[^\s]){1}\s{0,}}})/g, function(match, $1, $2) {
               return _get(scope.submission.data, $2);

--- a/src/directives/customValidator.js
+++ b/src/directives/customValidator.js
@@ -51,6 +51,7 @@ module.exports = function() {
         var row = scope.data;
         /*eslint-enable no-unused-vars */
 
+        var component = scope.component;
         var custom = scope.component.validate.custom;
         custom = custom.replace(/({{\s{0,}(.*[^\s]){1}\s{0,}}})/g, function(match, $1, $2) {
           return _get(scope.submission.data, $2);


### PR DESCRIPTION
Form builder text states "The global variables input, component, and valid are provided." but "component" is not really in scope.
Added it.