### PR TITLE
Prevent WYSIWYG settings from merging unintentionally 

### DIFF
--- a/src/components/textarea.js
+++ b/src/components/textarea.js
@@ -47,9 +47,6 @@ module.exports = function(app) {
             if ($scope.component.wysiwyg === true) {
               $scope.component.wysiwyg = defaults;
             }
-            else {
-              $scope.component.wysiwyg = angular.extend(defaults, $scope.component.wysiwyg);
-            }
 
             // FOR-929 - Remove spell check attribute
             if (!$scope.component.spellcheck){


### PR DESCRIPTION
FOR-1044

Changing a WYSIWYG's settings and then revisiting the component later (via editing it) will cause the settings to update due to them merging with defaults. Removing the merge resolves the issue. 