### PR TITLE
Access Formio stuff from "default" in provider

### DIFF
--- a/src/providers/Formio.js
+++ b/src/providers/Formio.js
@@ -6,17 +6,17 @@ module.exports = function() {
   return {
 
     // Expose Formio configuration functions
-    setBaseUrl: Formio.setBaseUrl,
-    getBaseUrl: Formio.getBaseUrl,
-    setApiUrl: Formio.setBaseUrl,
-    getApiUrl: Formio.getBaseUrl,
-    setAppUrl: Formio.setAppUrl,
-    setProjectUrl: Formio.setProjectUrl,
-    getAppUrl: Formio.getAppUrl,
-    getProjectUrl: Formio.getProjectUrl,
-    registerPlugin: Formio.registerPlugin,
-    getPlugin: Formio.getPlugin,
-    providers: Formio.providers,
+    setBaseUrl: Formio.default.setBaseUrl,
+    getBaseUrl: Formio.default.getBaseUrl,
+    setApiUrl: Formio.default.setBaseUrl,
+    getApiUrl: Formio.default.getBaseUrl,
+    setAppUrl: Formio.default.setAppUrl,
+    setProjectUrl: Formio.default.setProjectUrl,
+    getAppUrl: Formio.default.getAppUrl,
+    getProjectUrl: Formio.default.getProjectUrl,
+    registerPlugin: Formio.default.registerPlugin,
+    getPlugin: Formio.default.getPlugin,
+    providers: Formio.default.providers,
     setDomain: function() {
       // Remove this?
     },
@@ -42,7 +42,7 @@ module.exports = function() {
           });
         };
 
-        Formio.registerPlugin({
+        Formio.default.registerPlugin({
           priority: -100,
           // Wrap Formio.request's promises with $q so $apply gets called correctly.
           wrapRequestPromise: wrapQPromise,
@@ -50,7 +50,7 @@ module.exports = function() {
         }, 'ngFormioPromiseWrapper');
 
         // Broadcast offline events from $rootScope
-        Formio.events.onAny(function() {
+        Formio.default.events.onAny(function() {
           var event = 'formio.' + this.event;
           var args = [].splice.call(arguments, 0);
           args.unshift(event);
@@ -60,7 +60,7 @@ module.exports = function() {
         });
 
         // Return the formio interface.
-        return Formio;
+        return Formio.default;
       }
     ]
   };


### PR DESCRIPTION
Recent change in formio.js library pushed things used by FormioProvider down one level into `default`.
Access them from there.
May help with issues #542 and #543.