### PR TITLE
Removed double loadForm() method

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -165,7 +165,6 @@ module.exports = function(app) {
               if (!submission) {
                 return;
               }
-              loadForm();
               angular.merge($scope.data[$scope.component.key], submission);
             }, true);
           }


### PR DESCRIPTION
loadForm method is called twice in form.js - this is causing a problem where the formLoad event fires sporadically due to when a nested form component receives a response from the server.  Additionally this appears to be putting extra API calls onto the project's total since the forms are loaded twice. 


Broken View:
https://www.screencast.com/t/ZW9HfAVi2

Fixed View:
https://www.screencast.com/t/NrQvJChQopOL

