### PR TITLE
jsonLogic properly handles datetime components

### DIFF
--- a/src/directives/formioComponent.js
+++ b/src/directives/formioComponent.js
@@ -1,4 +1,5 @@
 var _get = require('lodash/get');
+var moment = require('moment');
 
 module.exports = [
   'Formio',
@@ -253,6 +254,9 @@ module.exports = [
 
                 var valid;
                 try {
+                  if ($scope.component.type === 'datetime') {
+                    $scope.data[$scope.component.key] = moment($scope.data[$scope.component.key]).toISOString();
+                  }
                   valid = FormioUtils.jsonLogic.apply(input, {
                     data: $scope.submission ? $scope.submission.data : $scope.data,
                     row: $scope.data


### PR DESCRIPTION
FormioUtils' custom operators for jsonLogic expect dates as an ISOString. ngformio now properly passes in the modified date value for proper validation.  