### PR TITLE
Fixed problem where datagrid add button disappears after removing maximum rows setting

### DIFF
--- a/src/templates/components/datagrid.html
+++ b/src/templates/components/datagrid.html
@@ -41,7 +41,7 @@
       </tr>
     </tbody>
   </table>
-  <div style="margin-top: 10px" class="datagrid-add" ng-if="(!component.hasOwnProperty('validate') || !component.validate.hasOwnProperty('maxLength') || rows.length < component.validate.maxLength) && (!component.addAnotherPosition || component.addAnotherPosition === 'bottom' || component.addAnotherPosition === 'both')">
+  <div style="margin-top: 10px" class="datagrid-add" ng-if="(!component.hasOwnProperty('validate') || !component.validate.hasOwnProperty('maxLength') || !component.validate.maxLength || rows.length < component.validate.maxLength) && (!component.addAnotherPosition || component.addAnotherPosition === 'bottom' || component.addAnotherPosition === 'both')">
     <a ng-click="(readOnly || formioForm.submitting)? null: addRow() " ng-disabled = "readOnly || formioForm.submitting" class="btn btn-primary">
       <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> {{ component.addAnother || "Add Another" | formioTranslate:null:options.building }}
     </a>


### PR DESCRIPTION
Create a form with a datagrid.
On grid's Validation tab set Maximum Length to 5.
Save form and test.
All good.
Go back to grid's Validation tab and remove Maximum Length (it will be stored as null).
Save form and test.
Add rows button will be missing and you can't add any rows to the grid.
Ored another check into the button's ng-if.