### PR TITLE
Construct new Formio if necessary

### DIFF
--- a/src/components/file.js
+++ b/src/components/file.js
@@ -275,14 +275,7 @@ module.exports = function(app) {
             };
             var dir = $scope.component.dir || '';
             dir = $interpolate(dir)({data: $scope.data, row: $scope.row});
-            var formio = null;
-            if ($scope.formio) {
-              formio = $scope.formio;
-            }
-            else {
-              $scope.fileUploads[fileName].status = 'error';
-              $scope.fileUploads[fileName].message = 'File Upload URL not provided.';
-            }
+            var formio = $scope.formio || new Formio();
 
             if (formio) {
               formio.uploadFile($scope.component.storage, file, fileName, dir, function processNotify(evt) {


### PR DESCRIPTION
Create an instance of the `<formio>` directive with the `form="..."` attribute where the form is defined in the $scope.
In the form definition include a file upload component with Storage = "Url" and a valid URL specified.
Trying to upload files through the component will error with 'File Upload URL not provided.' even though it has been provided.
Problem is when directive is used this way $scope.formio is null and when upload code sees this it just gives up.
Upload code can simply construct a new instance of Formio and use that and then the upload will work.

