### PR TITLE
Replace unmantained dependency that uses bower

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-formio",
-  "version": "2.35.5",
+  "version": "2.35.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -143,9 +143,10 @@
       "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.2.tgz",
       "integrity": "sha512-JcKKJbBdybUsmQ6x1M3xWyTYQ/ioVKJhSByEAjqrhmlOfvMFdhfMqAx5KIo8rLGk4DFolYPcCSgssjgTVjCtRQ=="
     },
-    "angular-ckeditor": {
-      "version": "github:lemonde/angular-ckeditor#655d52844515351a1c4f599f546dc2c5cf8cc44b",
-      "from": "github:lemonde/angular-ckeditor#v1.0.3"
+    "angular-ckeditor-legacy": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/angular-ckeditor-legacy/-/angular-ckeditor-legacy-1.0.3.tgz",
+      "integrity": "sha512-cwVmfyMu+llKu/u6Q0xCVrJaH/J6g8mRrPD4yGrd7ho2Nlx0lQ6l3hd1NHjrLjQg0/MwzOut7Jix4r8d/VkfHQ=="
     },
     "angular-file-saver": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "angular": "^1.7.2",
-    "angular-ckeditor": "lemonde/angular-ckeditor#v1.0.3",
+    "angular-ckeditor-legacy": "^1.0.3",
     "angular-file-saver": "^1.1.3",
     "angular-moment": "^1.2.0",
     "angular-sanitize": "^1.7.2",

--- a/src/formio-full.js
+++ b/src/formio-full.js
@@ -7,7 +7,7 @@ require('angular-file-saver');
 require('ng-file-upload');
 require('bootstrap');
 require('angular-ui-bootstrap');
-require('angular-ckeditor');
+require('angular-ckeditor-legacy');
 require('bootstrap-ui-datetime-picker/dist/datetime-picker');
 require('ng-dialog');
 require('angular-ui-ace/src/ui-ace');


### PR DESCRIPTION
The ckeditor dependency runs bower command after installing formio through npm.
Bower is deprecated and I need to exclude it from my development process.

I created a new package, forking ckeditor repo and removing the post install bower command from the package.json: https://github.com/lemonde/angular-ckeditor/blob/master/package.json#L7

This is my repo: https://github.com/CatBakun/angular-ckeditor-legacy/blob/master/package.json#L6

And this is the npm package: https://www.npmjs.com/package/angular-ckeditor-legacy

