### PR TITLE
v2.38.2 - File component not showing errors

### DIFF
--- a/src/components/file.js
+++ b/src/components/file.js
@@ -220,8 +220,18 @@ module.exports = function(app) {
       $scope.$watch('data.' + $scope.component.key, function(value) {
         // For some reason required validation doesn't fire properly after removing an item from an array which results
         // in an empty array that is marked as valid. Fix by removing the empty array.
-        if (Array.isArray(value) && value.length === 0) {
+        // Check also if the component value is an array with an empty string: [""]
+        const isEmptyArray = Array.isArray(value) && value.length === 0;
+        const isArrayWithEmptyItem = Array.isArray(value) && value.length === 1 && !value[0];
+        if (isEmptyArray || isArrayWithEmptyItem) {
           delete $scope.data[$scope.component.key];
+        }
+
+        // The file model is not getting dirty automatically
+        const form = $scope.$parent[$scope.formName];
+        const componentModel = form ? form[$scope.component.key] : null;
+        if (componentModel) {
+          componentModel.$setDirty();
         }
       }, true);
 


### PR DESCRIPTION
ngFormio Version: 2.38.2

Reproduce:
1 - Render a form with a required file component.
2 - Add a file
3 - Remove the file

Expected result: The required file component shows a validation error.

Actual result: The required file component never shows error messages.


This was happening for 2 things:
1 - The file component value is `[""]` after removing all images.
2 - The ngModel for the file component never gets dirty state.