### PR TITLE
Add min/max items file component validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,43 @@ node server</pre>
             when: null,
             eq: ''
           }
-        }, {
+        }, 
+        {
+          autofocus: false,
+          input: true,
+          tableView: true,
+          label: 'Test min-max',
+          key: 'page1TestminMax',
+          image: true,
+          imageSize: '200',
+          placeholder: '',
+          multiple: true,
+          defaultValue: '',
+          protected: false,
+          persistent: true,
+          hidden: false,
+          filePattern: '*',
+          fileMinSize: '0KB',
+          fileMaxSize: '1GB',
+          type: 'file',
+          storage: 's3',
+          slides: true,
+          labelPosition: 'top',
+          tags: [],
+          conditional: {
+              show: '',
+              when: null,
+              eq: ''
+          },
+          weight: 0,
+          properties: {},
+          validate: {
+              minItems: 1,
+              maxItems: 5
+          },
+          clearOnHide: true
+        },
+        {
           type: 'button',
           theme: 'primary',
           disableOnInvalid: true,
@@ -293,6 +329,19 @@ node server</pre>
           input: true
         }],
         display: 'form'
+      };
+      Formio.providers.storage.s3 = function() {
+        this.uploadFile = (file, key, dir, evt) => {
+          return {
+            name: file.name,
+            size: file.size,
+            type: file.type,
+            storage: 'url',
+            key: key,
+            url: 'https://help.form.io/assets/formio-logo.png'
+          }
+        };
+        this.downloadFile = fileInfo => fileInfo;
       };
     }]);
 </script>

--- a/src/components/file.js
+++ b/src/components/file.js
@@ -226,11 +226,11 @@ module.exports = function(app) {
         if (isEmptyArray || isArrayWithEmptyItem) {
           delete $scope.data[$scope.component.key];
         }
-
         // The file model is not getting dirty automatically
         var form = $scope.$parent[$scope.formName];
         var componentModel = form ? form[$scope.component.key] : null;
         if (componentModel) {
+          componentModel.$validate();
           componentModel.$setDirty();
         }
       }, true);
@@ -327,6 +327,35 @@ module.exports = function(app) {
       };
     }
   ]);
+  app.directive('validateItemsLength', function() {
+    return {
+      require: 'ngModel',
+      link: function(scope, ele, attrs, ngModelCtrl) {
+        ngModelCtrl.$validators.minItems = function(modelValue, viewValue) {
+          var isValid = true;
+          if (scope.component && !isNaN(scope.component.validate.minItems)) {
+            if (Array.isArray(modelValue)) {
+              isValid = modelValue.length >= scope.component.validate.minItems;
+            } else {
+              isValid = false;
+            }
+          }
+          ngModelCtrl.$error.minItems = !isValid;
+          return isValid;
+        }
+        ngModelCtrl.$validators.maxItems = function(modelValue, viewValue) {
+          var isValid = true;
+          if (scope.component && !isNaN(scope.component.validate.maxItems)) {
+            if (Array.isArray(modelValue)) {
+              isValid = modelValue.length <= scope.component.validate.maxItems;
+            }
+          }
+          ngModelCtrl.$error.maxItems = !isValid;
+          return isValid;
+        }
+      }
+    };
+  });
   app.run([
     '$templateCache',
     function(

--- a/src/templates/components/file.html
+++ b/src/templates/components/file.html
@@ -5,8 +5,8 @@
 <span ng-if="!component.label && isRequired(component)" class="glyphicon glyphicon-asterisk form-control-feedback field-required-inline" aria-hidden="true"></span>
 <div class="formio-errors"><formio-errors ng-if="::!options.building"></formio-errors></div>
 <div ng-controller="formioFileUpload" ng-style="getInputGroupStyles(component)">
-  <formio-file-list files="data[component.key]" form="formio.formUrl" ng-if="!component.image" ng-required="isRequired(component)" ng-model="data[component.key]" ng-model-options="{allowInvalid: true}" name="{{ componentId }}" read-only="readOnly"></formio-file-list>
-  <formio-image-list files="data[component.key]" form="formio.formUrl" width="component.imageSize" ng-if="component.image" ng-required="isRequired(component)" ng-model="data[component.key]" ng-model-options="{allowInvalid: true}" name="{{ componentId }}" read-only="readOnly"></formio-image-list>
+  <formio-file-list files="data[component.key]" form="formio.formUrl" ng-if="!component.image" ng-required="isRequired(component)" validate-items-length ng-model="data[component.key]" ng-model-options="{allowInvalid: true}" name="{{ componentId }}" read-only="readOnly"></formio-file-list>
+  <formio-image-list files="data[component.key]" form="formio.formUrl" width="component.imageSize" ng-if="component.image" validate-items-length ng-required="isRequired(component)" ng-model="data[component.key]" ng-model-options="{allowInvalid: true}" name="{{ componentId }}" read-only="readOnly"></formio-image-list>
   <div ng-if="!readOnly && (component.multiple || (!component.multiple && !data[component.key].length))">
     <div ngf-drop="upload($files, $invalidFiles)"
       class="fileSelector"

--- a/src/templates/errors.html
+++ b/src/templates/errors.html
@@ -5,6 +5,8 @@
     formioForm[componentId].$error.number ||
     formioForm[componentId].$error.maxlength ||
     formioForm[componentId].$error.minlength ||
+    formioForm[componentId].$error.maxItems ||
+    formioForm[componentId].$error.minItems ||
     formioForm[componentId].$error.min ||
     formioForm[componentId].$error.max ||
     formioForm[componentId].$error.custom ||
@@ -20,6 +22,8 @@
     <p class="help-block" ng-show="formioForm[componentId].$error.number">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'must be a number' | formioTranslate:null:options.building}}.</p>
     <p class="help-block" ng-show="formioForm[componentId].$error.maxlength">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'must be shorter than' | formioTranslate:null:options.building}} {{ component.validate.maxLength + 1 }} {{'characters' | formioTranslate:null:options.building}}.</p>
     <p class="help-block" ng-show="formioForm[componentId].$error.minlength">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'must be longer than' | formioTranslate:null:options.building}} {{ component.validate.minLength - 1 }} {{'characters' | formioTranslate:null:options.building}}.</p>
+    <p class="help-block" ng-show="formioForm[componentId].$error.maxItems">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'max items allowed: ' | formioTranslate:null:options.building}} {{ component.validate.maxItems }}.</p>
+    <p class="help-block" ng-show="formioForm[componentId].$error.minItems">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'min items required: ' | formioTranslate:null:options.building}} {{ component.validate.minItems }}.</p>
     <p class="help-block" ng-show="formioForm[componentId].$error.min">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'must be greater than or equal to' | formioTranslate:null:options.building}} {{ component.validate.min }}.</p>
     <p class="help-block" ng-show="formioForm[componentId].$error.max">{{ component.errorLabel || component.label || component.placeholder || component.key }} {{'must be less than or equal to' | formioTranslate:null:options.building}} {{ component.validate.max }}.</p>
     <p class="help-block" ng-show="formioForm[componentId].$error.custom">{{ component.customError | formioTranslate }}</p>


### PR DESCRIPTION
Form render support for: https://github.com/formio/formio/pull/857

* Added image component to the example.
* Add max/min items to errors template.
* Mocked file storage provider to test file component.
* Added angular min/max validation directive.
* File component data change should trigger ngModel validation.

Form Builder PR: https://github.com/formio/ngFormBuilder/pull/445