### PR TITLE
Add filter for translations to some component labels.

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -10,7 +10,8 @@ var _isNil = require('lodash/isNil');
 module.exports = function(app) {
   app.directive('formioSelectItem', [
     '$compile',
-    function($compile) {
+    '$filter',
+    function($compile, $filter) {
       return {
         restrict: 'E',
         scope: {
@@ -21,6 +22,9 @@ module.exports = function(app) {
         link: function(scope, element) {
           if (scope.options && scope.options.building) return;
           if (scope.template) {
+            if (scope.item) {
+              scope.item.label = $filter('formioTranslate')(scope.item.label);
+            }
             element.append($compile(angular.element(scope.template))(scope));
           }
         }

--- a/src/directives/formioComponentTooltip.js
+++ b/src/directives/formioComponentTooltip.js
@@ -6,7 +6,7 @@ module.exports = function() {
     template: '<i ng-if="component.tooltip"' +
     ' class="glyphicon glyphicon-question-sign"' +
     ' ng-class="{ \'text-muted\': component.type !== \'button\' }"' +
-    ' uib-tooltip="{{ component.tooltip }}"' +
+    ' uib-tooltip="{{ component.tooltip | formioTranslate:null:options.building }}"' +
     ' tooltip-placement="right"' +
     ' tooltip-popup-close-delay="100" id="{{component.key+\'Desc\'}}"></i>'
   };

--- a/src/templates/components/currency.html
+++ b/src/templates/components/currency.html
@@ -13,7 +13,7 @@
   auto-focus="true"
   aria-labelledby="{{ componentId +'Label'}}"
   aria-describedby="{{componentId + 'Desc'}}"
-  ng-attr-placeholder="{{ component.placeholder }}"
+  ng-attr-placeholder="{{ component.placeholder | formioTranslate:null:options.building}}"
   custom-validator="component.validate.custom"
   formio-mask="currency"
   formio-custom-attributes="{{component.attributes}}"

--- a/src/templates/components/day-input.html
+++ b/src/templates/components/day-input.html
@@ -13,7 +13,7 @@
         ng-change="onChange()"
         style="padding-right: 10px;"
         auto-focus="true"
-        ng-attr-placeholder="{{component.fields.day.placeholder}}"
+        ng-attr-placeholder="{{component.fields.day.placeholder | formioTranslate:null:options.building }}"
         day-part
         characters="2"
         min="1"
@@ -56,7 +56,7 @@
         style="padding-right: 10px;"
         aria-labelledby="{{ componentId }}-day1Label"
         auto-focus="{{ component.fields.month.hide }}"
-        ng-attr-placeholder="{{component.fields.day.placeholder}}"
+        ng-attr-placeholder="{{component.fields.day.placeholder | formioTranslate:null:options.building }}"
         day-part
         characters="2"
         min="1"
@@ -78,7 +78,7 @@
         ng-change="onChange()"
         aria-labelledby="{{ componentId }}-yearLabel"
         style="padding-right: 10px;"
-        ng-attr-placeholder="{{component.fields.year.placeholder}}"
+        ng-attr-placeholder="{{component.fields.year.placeholder | formioTranslate:null:options.building }}"
         auto-focus="{{ component.fields.day.hide && component.fields.month.hide }}"
         characters="4"
         min="0"

--- a/src/templates/components/select.html
+++ b/src/templates/components/select.html
@@ -42,6 +42,6 @@
   <formio-component-tooltip></formio-component-tooltip>
 </label>
 <div ng-if="!!component.description" class="help-block">
-  <span id="{{ componentId+'Desc' }}">{{ component.description }}</span>
+  <span id="{{ componentId+'Desc' }}">{{ component.description | formioTranslate:null:options.building }}</span>
 </div>
 <formio-errors ng-if="::!options.building"></formio-errors>

--- a/src/templates/components/selectboxes.html
+++ b/src/templates/components/selectboxes.html
@@ -1,6 +1,6 @@
 <fieldset ng-if="component.fieldSet">
   <legend ng-if="component.label" class="select-boxes-legend">
-    {{ component.label }}
+    {{ component.label | formioTranslate:null:options.building }}
     <formio-component-tooltip></formio-component-tooltip>
   </legend>
   <div class="select-boxes">
@@ -20,7 +20,7 @@
       ng-style="getInputGroupStyles(component)"
     ></formio-select-boxes>
     <div ng-if="!!component.description" class="help-block">
-      <span id="{{ componentId+'Desc'  }}">{{ component.description }}</span>
+      <span id="{{ componentId+'Desc'  }}">{{ component.description | formioTranslate:null:options.building }}</span>
     </div>
     <formio-errors ng-if="::!options.building"></formio-errors>
   </div>
@@ -28,7 +28,7 @@
 <div class="select-boxes" ng-if="!component.fieldSet">
   <label ng-if="labelVisible() && (component.labelPosition !== 'bottom')" for="{{ componentId }}" class="control-label select-boxes-label" id="{{ componentId+'Label' }}" ng-class="{'field-required': isRequired(component)}"
          ng-style="getLabelStyles(component)">
-    {{ component.label }}
+    {{ component.label | formioTranslate:null:options.building }}
     <formio-component-tooltip></formio-component-tooltip>
   </label>
   <formio-select-boxes
@@ -49,11 +49,11 @@
   ></formio-select-boxes>
   <label ng-if="labelVisible() && (component.labelPosition === 'bottom')" for="{{ componentId }}" class="control-label control-label--bottom" id="{{ componentId +'Desc'}}"
          ng-class="{'field-required': isRequired(component)}">
-    {{ component.label }}
+    {{ component.label | formioTranslate:null:options.building }}
     <formio-component-tooltip></formio-component-tooltip>
   </label>
   <div ng-if="!!component.description" class="help-block">
-    <span id="{{ componentId+'Desc' }}">{{ component.description }}</span>
+    <span id="{{ componentId+'Desc' }}">{{ component.description | formioTranslate:null:options.building }}</span>
   </div>
   <formio-errors ng-if="::!options.building"></formio-errors>
 </div>

--- a/src/templates/components/survey.html
+++ b/src/templates/components/survey.html
@@ -2,7 +2,7 @@
   <thead>
     <tr>
       <td></td>
-      <th ng-repeat="v in component.values track by $index" style="text-align: center;">{{ v.label }}</th>
+      <th ng-repeat="v in component.values track by $index" style="text-align: center;">{{ v.label | formioTranslate:null:options.building}}</th>
     </tr>
   </thead>
   <tr ng-repeat="question in component.questions"
@@ -10,7 +10,7 @@
     ng-class="{
       'text-danger': !formioForm[inputName].$pristine && formioForm[inputName].$invalid
     }">
-    <td>{{ question.label }}</td>
+    <td>{{ question.label | formioTranslate:null:options.building}}</td>
     <td ng-repeat="v in component.values track by $index" style="text-align: center;">
       <input
         type="radio"

--- a/src/templates/formio-wizard.html
+++ b/src/templates/formio-wizard.html
@@ -2,7 +2,7 @@
   <div class="row bs-wizard" style="border-bottom:0;" ng-class="{hasTitles: hasTitles}" ng-if="activePage.breadcrumb !== 'none'">
     <div ng-class="{disabled: ($index > currentPage) && !formioOptions.wizardFreeNavigation, active: ($index == currentPage), complete: ($index < currentPage), noTitle: !page.title}" class="{{ colclass }} bs-wizard-step" ng-repeat="page in pages track by $index">
       <div class="bs-wizard-stepnum-wrapper">
-        <div class="text-center bs-wizard-stepnum" ng-if="page.title">{{ page.title }}</div>
+        <div class="text-center bs-wizard-stepnum" ng-if="page.title">{{ page.title | formioTranslate:null:options.building }}</div>
       </div>
       <div class="progress"><div class="progress-bar progress-bar-primary"></div></div>
       <a ng-click="goto($index)" class="bs-wizard-dot bg-primary"><div class="bs-wizard-dot-inner"
@@ -31,13 +31,13 @@
     ></formio>
   </div>
   <ul ng-show="wizardLoaded" class="list-inline">
-    <li><a class="btn btn-default formio-wizard-button-cancel" ng-click="cancel()">Cancel</a></li>
-    <li ng-if="currentPage > 0"><a class="btn btn-primary formio-wizard-button-previous" ng-click="prev()">Previous</a></li>
+    <li><a class="btn btn-default formio-wizard-button-cancel" ng-click="cancel()">{{ 'cancel' | formioTranslate:null:options.building }}</a></li>
+    <li ng-if="currentPage > 0"><a class="btn btn-primary formio-wizard-button-previous" ng-click="prev()">{{ 'previous' | formioTranslate:null:options.building }}</a></li>
     <li ng-if="currentPage < (pages.length - 1)">
-      <a class="btn btn-primary formio-wizard-button-next" ng-click="next()">Next</a>
+      <a class="btn btn-primary formio-wizard-button-next" ng-click="next()">{{ 'next' | formioTranslate:null:options.building }}</a>
     </li>
     <li ng-if="currentPage >= (pages.length - 1)">
-      <a class="btn btn-primary formio-wizard-button-submit" ng-click="submit()">Submit Form</a>
+      <a class="btn btn-primary formio-wizard-button-submit" ng-click="submit()">{{ 'submit' | formioTranslate:null:options.building }}</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
Using filter formioTranslate to allow translations on the following components labels:
- Tooltips.
- Selectboxes.
- Placeholders on day component.
- Item label and description on select component.
- Placeholder on currency component.
- Label and questions on survey component.

Also added them to the wizard template:
- Button submit.
- Button cancel.
- Button next.
- Button previous.
- Page title.