### PR TITLE
Check if form is readOnly before clear select fields.

### DIFF
--- a/src/components/select.js
+++ b/src/components/select.js
@@ -191,7 +191,7 @@ module.exports = function(app) {
               refreshing = true;
               var tempData = $scope.data[settings.key];
               $scope.data[settings.key] = settings.multiple ? [] : '';
-              if (!settings.clearOnRefresh) {
+              if (!settings.clearOnRefresh || $scope.readOnly) {
                 $timeout(function() {
                   $scope.data[settings.key] = tempData;
                   refreshing = false;


### PR DESCRIPTION
When the form is on readOnly mode and there is a select with the flag clearOnRefresh, the select component get clear before it can show the submission value.