### PR TITLE
Pass formioOptions to formio.saveSubmission()

### DIFF
--- a/src/directives/formioWizard.js
+++ b/src/directives/formioWizard.js
@@ -374,7 +374,7 @@ module.exports = function() {
               }, FormioScope.onError($scope, $element));
             }
             else if ($scope.formio && !$scope.formio.noSubmit) {
-              $scope.formio.saveSubmission(submissionData).then(onDone).catch(FormioScope.onError($scope, $element));
+              $scope.formio.saveSubmission(submissionData, $scope.formioOptions).then(onDone).catch(FormioScope.onError($scope, $element));
             }
             else {
               onDone(submissionData);


### PR DESCRIPTION
Problem:
 When submitting from a multi page form using formio-wizard the `formioOptions` value is not been passed to `formio.saveSubmission()`.
Solution:
 Passing `formioOptions` to the function.