### PR TITLE
FIO-7324: fixed build process where webpack5 throw an error because of wrong arguments

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -73,7 +73,10 @@ module.exports = {
     ]
   },
   plugins: [
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^\.\/locale$/, 
+      contextRegExp: /moment$/
+    }),
     new webpack.ProvidePlugin({
       '$': 'jquery',
       'jQuery': 'jquery',

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -7,7 +7,10 @@ module.exports = merge(require('./webpack.dev'), {
     filename: 'ng-formio.min.js'
   },
   plugins: [
-    new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+    new webpack.IgnorePlugin({
+      resourceRegExp: /^\.\/locale$/, 
+      contextRegExp: /moment$/
+    }),
     new webpack.BannerPlugin(`ng-formio v${packageJSON.version} | https://unpkg.com/ngFormio@${packageJSON.version}/LICENSE.txt`)
   ]
 });


### PR DESCRIPTION
https://formio.atlassian.net/browse/FIO-7324

IgnorePlugin of webpack 5 expects arguments to be an object. Link to docs: https://webpack.js.org/plugins/ignore-plugin
