### PR TITLE
FIO-8631/FIO-8634: Fixes an issue where premium components show "Unknown template" on 5.x renderer

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -4,5 +4,5 @@ import './providers';
 import './directives';
 import './factories';
 import Utils from '@formio/js/utils';
-export { Formio } from '@formio/js/sdk';
+export { Formio } from '@formio/js';
 export { Utils };


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-8631
https://formio.atlassian.net/browse/FIO-8634

## Description

Importing from  "@formio/js/sdk" does not import the renderer itself, instead it should be lazyu loaded, but since it will reequire more steps to implement this , we decided that we won't make thje renderer in portal lazy loaded. 

## Breaking Changes / Backwards Compatibility

*Use this section to describe any potentially breaking changes this PR introduces or any effects this PR might have on backwards compatibility*

## Dependencies

*Use this section to list any dependent changes/PRs in other Form.io modules*

## How has this PR been tested?

*Use this section to describe how you tested your changes; if you haven't included automated tests, justify your reasoning*

## Checklist:

- [ ] I have completed the above PR template
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above